### PR TITLE
Add textStyle prop

### DIFF
--- a/src/VirtualKeyboard.js
+++ b/src/VirtualKeyboard.js
@@ -28,6 +28,7 @@ export default class VirtualKeyboard extends Component {
 		decimal: PropTypes.bool,
 		rowStyle: ViewPropTypes.style,
 		cellStyle: ViewPropTypes.style,
+		textStyle: Text.propTypes.style,
 		clearOnLongPress: PropTypes.bool,
 	}
 
@@ -84,7 +85,7 @@ export default class VirtualKeyboard extends Component {
 	Cell(symbol) {
 		return (
 			<TouchableOpacity style={[styles.cell, this.props.cellStyle]} key={symbol} accessibilityLabel={symbol.toString()} onPress={() => { this.onPress(symbol.toString()) }}>
-				<Text style={[styles.number, { color: this.props.color }]}>{symbol}</Text>
+				<Text style={[styles.number, this.props.textStyle, { color: this.props.color }]}>{symbol}</Text>
 			</TouchableOpacity>
 		);
 	}


### PR DESCRIPTION
Allow setting style for <Text>, which renders keyboard keys, like Cell styles and Row styles pull requests allowed styling Cells and Rows.

I find it important, because I needed to increase fontSize for my project. It makes the keyboard more accessible and configurable.

Default behaviour is unchanged.