### PR TITLE
Add support for a custom decimal symbol

### DIFF
--- a/src/VirtualKeyboard.js
+++ b/src/VirtualKeyboard.js
@@ -56,7 +56,7 @@ export default class VirtualKeyboard extends Component {
 				{this.Row([4, 5, 6])}
 				{this.Row([7, 8, 9])}
 				<View style={[styles.row, this.props.rowStyle]}>
-					{this.props.decimal ? this.props.decimalSymbol || this.Cell('.') : <View style={{ flex: 1 }} /> }
+					{this.props.decimal ? this.Cell(this.props.decimalSymbol) || this.Cell('.') : <View style={{ flex: 1 }} /> }
 					{this.Cell(0)}
 					{this.Backspace()}
 				</View>

--- a/src/VirtualKeyboard.js
+++ b/src/VirtualKeyboard.js
@@ -26,6 +26,7 @@ export default class VirtualKeyboard extends Component {
 		backspaceImg: PropTypes.number,
 		applyBackspaceTint: PropTypes.bool,
 		decimal: PropTypes.bool,
+		decimalSymbol: PropTypes.string,
 		rowStyle: ViewPropTypes.style,
 		cellStyle: ViewPropTypes.style,
 		textStyle: TextPropTypes.style,
@@ -55,7 +56,7 @@ export default class VirtualKeyboard extends Component {
 				{this.Row([4, 5, 6])}
 				{this.Row([7, 8, 9])}
 				<View style={[styles.row, this.props.rowStyle]}>
-					{this.props.decimal ? this.Cell('.') : <View style={{ flex: 1 }} /> }
+					{this.props.decimal ? this.props.decimalSymbol || this.Cell('.') : <View style={{ flex: 1 }} /> }
 					{this.Cell(0)}
 					{this.Backspace()}
 				</View>


### PR DESCRIPTION
Some languages (in our case specifically Norwegian) use `,` instead of `.` for decimal points. This PR adds support for a `decimalSymbol` prop that overrides the default `.` if set.